### PR TITLE
Add mobile-support email to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # fullstory-swift-package-ios
 
-Swift package artifacts for [the FullStory SDK for instrumenting iOS mobile apps](https://www.fullstory.com/mobile-apps/). See the [Getting Started with iOS Recording](https://help.fullstory.com/hc/en-us/articles/360042772333-Getting-Started-with-iOS-Recording) article in the FullStory Help Center for details on how to integrate this package into your iOS application.
+Swift package artifacts for [the FullStory SDK for instrumenting iOS mobile apps](https://www.fullstory.com/mobile-apps/). See the [Getting Started with iOS Recording](https://help.fullstory.com/hc/en-us/articles/360042772333-Getting-Started-with-iOS-Recording) article in the FullStory Help Center for details on how to integrate this package into your iOS application. Email mobile-support@fullstory.com for additional help.


### PR DESCRIPTION
Added the mobile-support email address to the readme now that the issues tab is disabled.