### PR TITLE
Bump actions/checkout v3 to v6

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         # Fetch all tags
         fetch-depth: 0
@@ -36,9 +36,11 @@ jobs:
         # Fetch the Package.swift for this version.
         curl -sS "https://ios-releases.fullstory.com/fullstory-${version}-xcframework-Package.swift" > Package.swift
 
-        # Commit the changes, tag them, push it all
-        git config user.email "action@github.com"
-        git config user.name "GitHub Actions"
-        git commit -am "Update package for ${version} release"
+        # Commit the changes, tag them, push it all.
+        # This bot account is the one GitHub recommends for actions that push commits.
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add Package.swift
+        git commit -m "Update package for ${version} release"
         git tag $version
         git push --tags origin master

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         # Fetch all tags
         fetch-depth: 0


### PR DESCRIPTION
GitHub is deprecating Node.js 20 on Actions runners. `actions/checkout@v3` uses Node.js 20, which stops working Sept 16, 2026 (and gets forced to Node.js 24 on June 2).

Bumped it to v6 (the latest). Same inputs, same behavior, just runs on a supported Node version.

While in here I also cleaned up the commit step per review:

- Switched the commit to the `github-actions[bot]` account that GitHub recommends for actions that push commits.
- Stage `Package.swift` explicitly instead of `git add -a`, and kept the original commit message.

I tested the commit/tag/push logic against a throwaway repo. The no-update case and the new-version case both still work.